### PR TITLE
TP-411: Force hostname to `localhost` in integration tests

### DIFF
--- a/src/main/java/com/avanza/gs/test/PuConfigurers.java
+++ b/src/main/java/com/avanza/gs/test/PuConfigurers.java
@@ -17,6 +17,22 @@ package com.avanza.gs.test;
 
 public class PuConfigurers {
 
+	static {
+		// This needs to be executed before anything about GS is initialized,
+		// such as the static block in JVMGlobalLus
+		setSystemProperties();
+	}
+
+	private static void setSystemProperties() {
+		if (System.getProperty("java.rmi.server.hostname") == null) {
+			// Overrides values resolved by GigaSpaces
+			// {@link NIOInfoHelper#getLocalHostAddress} and
+			// {@link NIOInfoHelper#getLocalHostName} via
+			// {@link BootUtil#getHost}
+			System.setProperty("java.rmi.server.hostname", "localhost");
+		}
+	}
+
 	public static PartitionedPuConfigurer partitionedPu(String puXmlPath) {
 		return new PartitionedPuConfigurer(puXmlPath);
 	}


### PR DESCRIPTION
Same as #6 , but for gs14 branch.

* Sets the hostname to `localhost` when running integration tests
* Reason for setting this is to make it easier to run the tests on hosts whose networking is configured in a nonstandard way where `InetAddress.getLocalHost()` does not return `127.0.0.1` or `localhost`.