### PR TITLE
TP-325: Allow singleton CredentialsProvider during GS tests

### DIFF
--- a/src/main/java/com/avanza/gs/test/PartitionedPu.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPu.java
@@ -90,7 +90,10 @@ public final class PartitionedPu implements PuRunner {
 		final Properties contextProperties = provider.getBeanLevelProperties().getContextProperties();
 		contextProperties.put("com.gs.security.security-manager.class", new SecurityManagerForTests());
 		// SecurityManagerForTests will accept all credentials, so these can be anything
-		provider.setCredentialsProvider(new DefaultCredentialsProvider("", ""));
+		final DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider("", "");
+		provider.setCredentialsProvider(credentialsProvider);
+		// Despite its name, this property is read by com.avanza.astrix.gs.ClusteredProxyCacheImpl
+		System.getProperties().put("com.gs.security.credentials-provider.class", credentialsProvider);
 
 		// Override default timeouts that are being used when security is enabled
 		// during PU startup.


### PR DESCRIPTION
Same as #8 , but for gs14 branch.

* Adds a singleton instance of a `CredentialsProvider` during GigaSpaces integration tests
* The reason for adding it is to make Astrix use the correct credentials during integration tests, instead of an actual implementation.