### PR TITLE
TP-415: Always run `maven-source-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,21 +49,6 @@
 					</executions>
 				</plugin>
 				-->
-				
-				<!-- This plugin makes sure that a source jar is always built together 
-					with the binary jar -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>attach-sources</id>
-							<goals>
-								<goal>jar</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
 	
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -369,6 +354,21 @@
 					<execution>
 						<goals>
 							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- This plugin makes sure that a source jar is always built together
+				with the binary jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
* Updates pom so that `maven-source-plugin` is always executed when building, instead of (previously) only in the `release` profile with `-Prelease`.