### PR TITLE
TP-415: Always run `maven-source-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,21 +34,6 @@
 			<!--  javadoc, source and gpg plugin from above -->
 			<!-- All artifacts deployed to the central repository must be signed -->
 			<plugins>
-				
-				<!-- This plugin makes sure that a source jar is always built together 
-					with the binary jar -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-source-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>attach-sources</id>
-							<goals>
-								<goal>jar</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
 	
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -365,6 +350,21 @@
 					<execution>
 						<goals>
 							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- This plugin makes sure that a source jar is always built together
+				with the binary jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Same as #10 , but for gs14 branch

* Updates pom so that `maven-source-plugin` is always executed when building, instead of (previously) only in the `release` profile with `-Prelease`.