### PR TITLE
TP-431: Require user/pass during IT

### DIFF
--- a/src/main/java/com/avanza/gs/test/PartitionedPu.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPu.java
@@ -90,7 +90,7 @@ public final class PartitionedPu implements PuRunner {
 		final Properties contextProperties = provider.getBeanLevelProperties().getContextProperties();
 		contextProperties.put("com.gs.security.security-manager.class", new SecurityManagerForTests());
 		// SecurityManagerForTests will accept all credentials, so these can be anything
-		final DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider("", "");
+		final DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider(SecurityManagerForTests.TEST_USER, SecurityManagerForTests.TEST_PASS);
 		provider.setCredentialsProvider(credentialsProvider);
 		// Despite its name, this property is read by com.avanza.astrix.gs.ClusteredProxyCacheImpl
 		System.getProperties().put("com.gs.security.credentials-provider.class", credentialsProvider);

--- a/src/main/java/com/avanza/gs/test/SecurityManagerForTests.java
+++ b/src/main/java/com/avanza/gs/test/SecurityManagerForTests.java
@@ -31,6 +31,9 @@ import com.gigaspaces.security.directory.User;
 import com.gigaspaces.security.directory.UserDetails;
 
 public class SecurityManagerForTests implements SecurityManager, Serializable {
+
+	public static final String TEST_USER = "testuser";
+	public static final String TEST_PASS = "testpass";
 	private static final Authority[] TEST_AUTHORITIES = Stream.of(SpaceAuthority.SpacePrivilege.values())
 			.map(SpaceAuthority::new)
 			.toArray(Authority[]::new);
@@ -47,8 +50,19 @@ public class SecurityManagerForTests implements SecurityManager, Serializable {
 	}
 
 	@Override
-	public Authentication authenticate(UserDetails userDetails) throws AuthenticationException {
-		// During tests, we allow any username & password
-		return new Authentication(new User(userDetails.getUsername(), userDetails.getPassword(), TEST_AUTHORITIES));
+	public Authentication authenticate(UserDetails u) throws AuthenticationException {
+		if (!TEST_USER.equals(u.getUsername())) {
+			throw new AuthenticationException(
+					"Incorrect auth username for test login. "
+							+ "Expected [" + TEST_USER + "] but received [" + u.getUsername() + "]"
+			);
+		}
+		if (!TEST_PASS.equals(u.getPassword())) {
+			throw new AuthenticationException(
+					"Incorrect auth password for test login. "
+							+ "Expected [" + TEST_PASS + "] but received [" + u.getPassword() + "]"
+			);
+		}
+		return new Authentication(new User(TEST_USER, TEST_PASS, TEST_AUTHORITIES));
 	}
 }


### PR DESCRIPTION
* Enables checking for a certain username/password during integration tests.
* Reason for checking is to enable making integration tests that supply incorrect credentials and validate that such connections are not possible.
* The implementation in this commit makes `SecurityManagerForTests` be identical to the one from Astrix, as a first step in using this library from Astrix instead of it being copied to two places.