### PR TITLE
TP-822: Allow embedded PUs with spring config as class ref

### DIFF
--- a/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
+++ b/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.springframework.util.StreamUtils;
+
+public class PuXmlEmulation {
+	public static Path createPuXmlConf(Class<?> puConfig) {
+		try (InputStream in = PuXmlEmulation.class.getResourceAsStream("/pu.xml.template")) {
+			Path tempFile = Files.createTempFile("config", ".xml");
+			String content = StreamUtils.copyToString(in, UTF_8)
+					.replace("##CLASSNAME##", puConfig.getName());
+			Files.write(tempFile, content.getBytes(UTF_8));
+			return tempFile;
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+}

--- a/src/main/resources/pu.xml.template
+++ b/src/main/resources/pu.xml.template
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:annotation-config/>
+    <bean class="##CLASSNAME##"/>
+</beans>

--- a/src/test/java/com/avanza/gs/test/PuXmlEmulationTest.java
+++ b/src/test/java/com/avanza/gs/test/PuXmlEmulationTest.java
@@ -16,22 +16,28 @@
 package com.avanza.gs.test;
 
 import static com.avanza.gs.test.PuXmlEmulation.createPuXmlConf;
+import static java.nio.file.Files.readAllLines;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-public class PuConfigurers {
+import java.nio.file.Path;
+import java.util.List;
 
-	public static PartitionedPuConfigurer partitionedPu(String puXmlPath) {
-		return new PartitionedPuConfigurer(puXmlPath);
+import org.junit.Test;
+import org.springframework.context.annotation.Configuration;
+
+public class PuXmlEmulationTest {
+	@Test
+	public void shouldProduceSpringXmlConfigThatReferencesSingleClass() throws Exception {
+		// Act
+		Path xmlFile = createPuXmlConf(SpringConfig.class);
+
+		// Assert
+		List<String> lines = readAllLines(xmlFile);
+		assertThat(lines, hasItem("    <bean class=\"com.avanza.gs.test.PuXmlEmulationTest$SpringConfig\"/>"));
 	}
 
-	public static PartitionedPuConfigurer partitionedPu(Class<?> puConfig) {
-		return partitionedPu(createPuXmlConf(puConfig).toUri().toString());
-	}
-
-	public static MirrorPuConfigurer mirrorPu(String puXmlPath) {
-		return new MirrorPuConfigurer(puXmlPath);
-	}
-
-	public static MirrorPuConfigurer mirrorPu(Class<?> mirrorConfig) {
-		return mirrorPu(createPuXmlConf(mirrorConfig).toUri().toString());
+	@Configuration
+	public static class SpringConfig {
 	}
 }


### PR DESCRIPTION
* Allows starting embedded PUs from `PuConfigurers` by specifying the spring config as a `Class` reference, instead of always relying on having `pu.xml`.
* Reason for adding is to allow apps that do not necessarily have a `pu.xml` to run tests on their spaces.