### PR TITLE
Exclude optional XAP dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,77 @@
 		<dependency>
 			<groupId>org.gigaspaces</groupId>
 			<artifactId>xap-openspaces</artifactId>
+			<!-- Exclusions are based on libraries not in the "required" folder in a gigaspaces installation -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.gigaspaces</groupId>
+					<artifactId>xap-jms</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.hibernate</groupId>
+					<artifactId>hibernate-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ow2.jotm</groupId>
+					<artifactId>jotm-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-jdbc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-orm</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework</groupId>
+					<artifactId>spring-web</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.security</groupId>
+					<artifactId>spring-security-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.security</groupId>
+					<artifactId>spring-security-web</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.security</groupId>
+					<artifactId>spring-security-config</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jboss.jbossts</groupId>
+					<artifactId>jbossjta</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.jboss.spec.javax.servlet</groupId>
+					<artifactId>jboss-servlet-api_3.0_spec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.hsqldb</groupId>
+					<artifactId>hsqldb</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.openjpa</groupId>
+					<artifactId>openjpa</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.atomikos</groupId>
+					<artifactId>transactions-jta</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jpa_2.0_spec</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>


### PR DESCRIPTION
Exclude transitive dependencies from `xap-openspaces` that are not in the `required` folder in a Gigaspaces installation.
This is to prevent errors when used in a Spring Boot application where Spring Boot tries to autoconfigure for example Atomikos JTA based on its presence on the classpath.