### PR TITLE
Allow configuring MirrorPu and PartitionedPu using a Resource.

### DIFF
--- a/src/main/java/com/avanza/gs/test/MirrorPu.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPu.java
@@ -15,27 +15,30 @@
  */
 package com.avanza.gs.test;
 
+import java.io.IOException;
+import java.util.Properties;
+
 import org.openspaces.core.GigaSpace;
 import org.openspaces.core.properties.BeanLevelProperties;
 import org.openspaces.pu.container.integrated.IntegratedProcessingUnitContainer;
 import org.openspaces.pu.container.integrated.IntegratedProcessingUnitContainerProvider;
 import org.springframework.context.ApplicationContext;
-
-import java.io.IOException;
-import java.util.Properties;
+import org.springframework.core.io.Resource;
 
 public class MirrorPu implements PuRunner {
 
 	private IntegratedProcessingUnitContainer container;
 	private final String gigaSpaceBeanName = "gigaSpace";
 	private final String puXmlPath;
-	private Properties contextProperties = new Properties();
+	private final Resource puConfigResource;
+	private final Properties contextProperties;
 	private final String lookupGroupName;
 	private final boolean autostart;
 	private final ApplicationContext parentContext;
 	
 	public MirrorPu(MirrorPuConfigurer config) {
 		this.puXmlPath = config.puXmlPath;
+		this.puConfigResource = config.puConfigResource;
 		this.contextProperties = config.properties;
 		this.lookupGroupName = config.lookupGroupName;
 		this.autostart = true;
@@ -45,7 +48,7 @@ public class MirrorPu implements PuRunner {
 	}
 
 	@Override
-	public void run() throws IOException {
+	public void run() {
 		try {
 			startContainers();
 		} catch (Exception e) {
@@ -56,7 +59,12 @@ public class MirrorPu implements PuRunner {
 	private void startContainers() throws IOException {
 		IntegratedProcessingUnitContainerProvider provider = new IntegratedProcessingUnitContainerProvider();
 		provider.setBeanLevelProperties(createBeanLevelProperties());
-		provider.addConfigLocation(puXmlPath);
+		if (puXmlPath != null) {
+			provider.addConfigLocation(puXmlPath);
+		}
+		if (puConfigResource != null) {
+			provider.addConfigLocation(puConfigResource);
+		}
 		if (parentContext != null) {
 			provider.setParentContext(parentContext);
 		}
@@ -86,7 +94,7 @@ public class MirrorPu implements PuRunner {
 	
 	@Override
 	public GigaSpace getClusteredGigaSpace() {
-		return GigaSpace.class.cast(container.getApplicationContext().getBean(this.gigaSpaceBeanName)).getClustered();
+		return container.getApplicationContext().getBean(this.gigaSpaceBeanName, GigaSpace.class).getClustered();
 	}
 	
 	@Override

--- a/src/main/java/com/avanza/gs/test/MirrorPu.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPu.java
@@ -59,7 +59,10 @@ public class MirrorPu implements PuRunner {
 	private void startContainers() throws IOException {
 		IntegratedProcessingUnitContainerProvider provider = new IntegratedProcessingUnitContainerProvider();
 		provider.setBeanLevelProperties(createBeanLevelProperties());
-		if (puXmlPath != null) {
+		if (puXmlPath == null && puConfigResource == null) {
+			throw new IllegalArgumentException("Either puXmlPath or puConfigResource needs to be set");
+		}
+ 		if (puXmlPath != null) {
 			provider.addConfigLocation(puXmlPath);
 		}
 		if (puConfigResource != null) {

--- a/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
@@ -18,16 +18,22 @@ package com.avanza.gs.test;
 import java.util.Properties;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
 
 public class MirrorPuConfigurer {
-	
-	final String puXmlPath;
+
+	String puXmlPath;
+	Resource puConfigResource;
 	Properties properties = new Properties();
 	ApplicationContext parentContext;
 	String lookupGroupName = JVMGlobalLus.getLookupGroupName();
 
 	public MirrorPuConfigurer(String puXmlPath) {
 		this.puXmlPath = puXmlPath;
+	}
+
+	public MirrorPuConfigurer(Resource puConfigResource) {
+		this.puConfigResource = puConfigResource;
 	}
 
 	public MirrorPuConfigurer contextProperty(String propertyName, String propertyValue) {

--- a/src/main/java/com/avanza/gs/test/PartitionedPu.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPu.java
@@ -80,6 +80,9 @@ public final class PartitionedPu implements PuRunner {
 		IntegratedProcessingUnitContainerProvider provider = new IntegratedProcessingUnitContainerProvider();
 		provider.setBeanLevelProperties(createBeanLevelProperties());
 		provider.setClusterInfo(createClusterInfo());
+		if (puXmlPath == null && puConfigResource == null) {
+			throw new IllegalArgumentException("Either puXmlPath or puConfigResource needs to be set");
+		}
 		if (puXmlPath != null) {
 			provider.addConfigLocation(puXmlPath);
 		}

--- a/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
@@ -20,10 +20,12 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
 
 public final class PartitionedPuConfigurer {
 	
 	String puXmlPath;
+	Resource puConfigResource;
 	int numberOfPrimaries = 1;
 	int numberOfBackups = 0;
 	boolean startAsync = false;
@@ -38,7 +40,11 @@ public final class PartitionedPuConfigurer {
 	public PartitionedPuConfigurer(String puXmlPath) {
 		this.puXmlPath = puXmlPath;
 	}
-	
+
+	public PartitionedPuConfigurer(Resource puConfigResource) {
+		this.puConfigResource = puConfigResource;
+	}
+
 	public PartitionedPuConfigurer parentContext(ApplicationContext parentContext) {
 		this.parentContext = parentContext;
 		return this;

--- a/src/main/java/com/avanza/gs/test/PuConfigurers.java
+++ b/src/main/java/com/avanza/gs/test/PuConfigurers.java
@@ -15,7 +15,9 @@
  */
 package com.avanza.gs.test;
 
-import static com.avanza.gs.test.PuXmlEmulation.createPuXmlConf;
+import static com.avanza.gs.test.PuXmlEmulation.createPuXmlResource;
+
+import org.springframework.core.io.Resource;
 
 public class PuConfigurers {
 
@@ -23,15 +25,24 @@ public class PuConfigurers {
 		return new PartitionedPuConfigurer(puXmlPath);
 	}
 
+	public static PartitionedPuConfigurer partitionedPu(Resource puConfigResource) {
+		return new PartitionedPuConfigurer(puConfigResource);
+	}
+
 	public static PartitionedPuConfigurer partitionedPu(Class<?> puConfig) {
-		return partitionedPu(createPuXmlConf(puConfig).toUri().toString());
+		return partitionedPu(createPuXmlResource(puConfig));
 	}
 
 	public static MirrorPuConfigurer mirrorPu(String puXmlPath) {
 		return new MirrorPuConfigurer(puXmlPath);
 	}
 
-	public static MirrorPuConfigurer mirrorPu(Class<?> mirrorConfig) {
-		return mirrorPu(createPuXmlConf(mirrorConfig).toUri().toString());
+	public static MirrorPuConfigurer mirrorPu(Resource puConfigResource) {
+		return new MirrorPuConfigurer(puConfigResource);
 	}
+
+	public static MirrorPuConfigurer mirrorPu(Class<?> mirrorConfig) {
+		return mirrorPu(createPuXmlResource(mirrorConfig));
+	}
+
 }

--- a/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
+++ b/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
@@ -23,18 +23,30 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 
 public class PuXmlEmulation {
+
 	public static Path createPuXmlConf(Class<?> puConfig) {
-		try (InputStream in = PuXmlEmulation.class.getResourceAsStream("/pu.xml.template")) {
+		try (InputStream in = createPuXmlResource(puConfig).getInputStream()) {
 			Path tempFile = Files.createTempFile("config", ".xml");
-			String content = StreamUtils.copyToString(in, UTF_8)
-					.replace("##CLASSNAME##", puConfig.getName());
-			Files.write(tempFile, content.getBytes(UTF_8));
+			Files.copy(in, tempFile);
 			return tempFile;
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
 	}
+
+	static Resource createPuXmlResource(Class<?> puConfig) {
+		try (InputStream in = PuXmlEmulation.class.getResourceAsStream("/pu.xml.template")) {
+			String content = StreamUtils.copyToString(in, UTF_8)
+					.replace("##CLASSNAME##", puConfig.getName());
+			return new ByteArrayResource(content.getBytes(UTF_8));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
 }

--- a/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
+++ b/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
@@ -16,6 +16,7 @@
 package com.avanza.gs.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,7 +33,7 @@ public class PuXmlEmulation {
 	public static Path createPuXmlConf(Class<?> puConfig) {
 		try (InputStream in = createPuXmlResource(puConfig).getInputStream()) {
 			Path tempFile = Files.createTempFile("config", ".xml");
-			Files.copy(in, tempFile);
+			Files.copy(in, tempFile, REPLACE_EXISTING);
 			return tempFile;
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);


### PR DESCRIPTION
This simplifies the process of generating an XML configuration, because it does not have to be written to disk before use.