### PR TITLE
TP-1027: Fix fetching application context from RunningPu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
 					<groupId>com.atomikos</groupId>
 					<artifactId>transactions-jta</artifactId>
 				</exclusion>
+				<!-- Do not include junit-jupiter from GigaSpaces -->
+				<exclusion>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -186,6 +191,11 @@
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -221,6 +231,7 @@
 		<gigaspaces.version>16.1.0</gigaspaces.version>
 		<junit.version>4.13.2</junit.version>
 		<hamcrest.version>2.2</hamcrest.version>
+		<log4j.version>2.17.2</log4j.version>
 	</properties>
 
 	<dependencyManagement>
@@ -237,7 +248,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${log4j.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>

--- a/src/main/java/com/avanza/gs/test/AsyncPuRunner.java
+++ b/src/main/java/com/avanza/gs/test/AsyncPuRunner.java
@@ -87,6 +87,11 @@ public class AsyncPuRunner implements PuRunner {
 	}
 
 	@Override
+	public ApplicationContext getBackupInstanceApplicationContext(int partition, int backup) {
+		return get(() -> puRunner.getBackupInstanceApplicationContext(partition, backup));
+	}
+
+	@Override
 	public int getNumInstances() {
 		return puRunner.getNumInstances();
 	}

--- a/src/main/java/com/avanza/gs/test/MirrorPu.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPu.java
@@ -106,6 +106,11 @@ public class MirrorPu implements PuRunner {
 	}
 
 	@Override
+	public ApplicationContext getBackupInstanceApplicationContext(int partition, int backup) {
+		throw new UnsupportedOperationException("Mirror PU does not contain any backup");
+	}
+
+	@Override
 	public int getNumInstances() {
 		return 1;
 	}

--- a/src/main/java/com/avanza/gs/test/PuRunner.java
+++ b/src/main/java/com/avanza/gs/test/PuRunner.java
@@ -34,4 +34,6 @@ public interface PuRunner {
 
 	ApplicationContext getPrimaryInstanceApplicationContext(int partition);
 
+	ApplicationContext getBackupInstanceApplicationContext(int partition, int backup);
+
 }

--- a/src/main/java/com/avanza/gs/test/RunningPu.java
+++ b/src/main/java/com/avanza/gs/test/RunningPu.java
@@ -15,12 +15,13 @@
  */
 package com.avanza.gs.test;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.junit.rules.TestRule;
 import org.openspaces.core.GigaSpace;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
-
-import java.util.Collection;
+import org.springframework.context.ApplicationContext;
 
 public interface RunningPu extends TestRule, AutoCloseable  {
 	
@@ -34,8 +35,20 @@ public interface RunningPu extends TestRule, AutoCloseable  {
 	
 	void stop() throws Exception;
 
-	BeanFactory getPrimaryInstanceApplicationContext(int partition);
+	ApplicationContext getPrimaryInstanceApplicationContext(int partition);
 
-	Collection<ListableBeanFactory> getApplicationContexts();
+	ApplicationContext getBackupInstanceApplicationContext(int partition, int backup);
+
+	/**
+	 * @deprecated use {@link #getPrimaryApplicationContexts()}
+	 */
+	@Deprecated
+	default Collection<ListableBeanFactory> getApplicationContexts() {
+		return getPrimaryApplicationContexts().stream()
+				.map(context -> (ListableBeanFactory) context)
+				.collect(Collectors.toList());
+	}
+
+	Collection<ApplicationContext> getPrimaryApplicationContexts();
 
 }

--- a/src/main/java/com/avanza/gs/test/RunningPuImpl.java
+++ b/src/main/java/com/avanza/gs/test/RunningPuImpl.java
@@ -15,15 +15,14 @@
  */
 package com.avanza.gs.test;
 
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-import org.openspaces.core.GigaSpace;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.ListableBeanFactory;
-
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.openspaces.core.GigaSpace;
+import org.springframework.context.ApplicationContext;
 
 public class RunningPuImpl implements RunningPu {
 
@@ -127,14 +126,19 @@ public class RunningPuImpl implements RunningPu {
     }
 
     @Override
-    public BeanFactory getPrimaryInstanceApplicationContext(int partition) {
+    public ApplicationContext getPrimaryInstanceApplicationContext(int partition) {
         return this.runner.getPrimaryInstanceApplicationContext(partition);
     }
 
     @Override
-    public Collection<ListableBeanFactory> getApplicationContexts() {
+    public ApplicationContext getBackupInstanceApplicationContext(int partition, int backup) {
+        return this.runner.getBackupInstanceApplicationContext(partition, backup);
+    }
+
+    @Override
+    public Collection<ApplicationContext> getPrimaryApplicationContexts() {
         return IntStream.range(0, runner.getNumInstances())
-                .mapToObj(partition -> runner.getPrimaryInstanceApplicationContext(partition))
+                .mapToObj(runner::getPrimaryInstanceApplicationContext)
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/avanza/gs/test/ContainerApplicationContextTest.java
+++ b/src/test/java/com/avanza/gs/test/ContainerApplicationContextTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.openspaces.core.GigaSpace;
+import org.springframework.context.ApplicationContext;
+
+public class ContainerApplicationContextTest {
+
+	private static final String SPACE_NAME = "fruit-space";
+
+	@Test
+	public void testFetchingApplicationContextWithBackup() throws Exception {
+		try (RunningPu fruitPu = PuConfigurers.partitionedPu("classpath:/fruit-pu.xml")
+				.numberOfPrimaries(2)
+				.numberOfBackups(1)
+				.configure()) {
+			fruitPu.start();
+
+			ApplicationContext primaryContext1 = fruitPu.getPrimaryInstanceApplicationContext(0);
+			ApplicationContext primaryContext2 = fruitPu.getPrimaryInstanceApplicationContext(1);
+			ApplicationContext backupContext1 = fruitPu.getBackupInstanceApplicationContext(0, 1);
+			ApplicationContext backupContext2 = fruitPu.getBackupInstanceApplicationContext(1, 1);
+
+			// Verify that the context for the correct container is fetched
+			assertThat(containerName(primaryContext1), is(expectedContainerName(1)));
+			assertThat(containerName(primaryContext2), is(expectedContainerName(2)));
+			assertThat(containerName(backupContext1), is(expectedContainerName(1, 1)));
+			assertThat(containerName(backupContext2), is(expectedContainerName(2, 1)));
+
+			// Verify fetching invalid contexts should fail validation
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getPrimaryInstanceApplicationContext(-1));
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getPrimaryInstanceApplicationContext(2));
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getBackupInstanceApplicationContext(0, 0));
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getBackupInstanceApplicationContext(0, 2));
+		}
+	}
+
+	@Test
+	public void testFetchingApplicationContextWithoutBackup() throws Exception {
+		try (RunningPu fruitPu = PuConfigurers.partitionedPu("classpath:/fruit-pu.xml")
+				.numberOfPrimaries(2)
+				.numberOfBackups(0)
+				.configure()) {
+			fruitPu.start();
+
+			ApplicationContext primaryContext1 = fruitPu.getPrimaryInstanceApplicationContext(0);
+			ApplicationContext primaryContext2 = fruitPu.getPrimaryInstanceApplicationContext(1);
+
+			// Verify that the context for the correct container is fetched
+			assertThat(containerName(primaryContext1), is(expectedContainerName(1)));
+			assertThat(containerName(primaryContext2), is(expectedContainerName(2)));
+
+			// Verify fetching backup context should fail validation when configured without backup
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getBackupInstanceApplicationContext(0, 1));
+			assertThrows(IllegalArgumentException.class, () -> fruitPu.getBackupInstanceApplicationContext(1, 1));
+		}
+	}
+
+	private static String containerName(ApplicationContext context) {
+		return context.getBean(GigaSpace.class).getSpace().getContainerName();
+	}
+
+	private static String expectedContainerName(int partition) {
+		return SPACE_NAME + "_container" + partition;
+	}
+
+	// GigaSpaces format for container name contains partition and backup number like space_container1_1
+	private static String expectedContainerName(int partition, int backup) {
+		return expectedContainerName(partition) + "_" + backup;
+	}
+
+}

--- a/src/test/resources/fruit-pu.xml
+++ b/src/test/resources/fruit-pu.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:os-core="http://www.openspaces.org/schema/core"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.openspaces.org/schema/core http://www.openspaces.org/schema/core/openspaces-core.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<os-core:giga-space id="gigaSpace" space="fruitSpace" />
+	<os-core:space id="fruitSpace" url="/./fruit-space" mirror="true">
+        <os-core:properties>
+	        <props>
+				<prop key="space-config.engine.cache_policy">1</prop>
+				<prop key="space-config.external-data-source.usage">read-only</prop>
+				<prop key="cluster-config.cache-loader.external-data-source">true</prop>
+				<prop key="cluster-config.cache-loader.central-data-source">true</prop>
+	        </props>
+	    </os-core:properties>
+    </os-core:space>
+
+</beans>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
 	<Appenders>
 		<Console name="Console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+			<PatternLayout pattern="%d{HH:mm:ss} %-5p %-30c{1} - %m%n" />
 		</Console>
 	</Appenders>
 	<Loggers>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="%-4r [%t] %-5p %c %x - %m%n"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="info">
+			<AppenderRef ref="Console"/>
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
* `getPrimaryInstanceApplicationContext(int partition)` returned the wrong application context when having a backup instance started and fetching `partition > 0`
* Naming of method `getApplicationContexts()` was misleading in that it only returns application context for primary contexts.
  I suggest we deprecate this method and also return `ApplicationContext` instead of `ListableBeanFactory`.
* Also return `ApplicationContext` from other methods fetching ApplicationContext from container