### PR TITLE
TP-687: Add JUnit5 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 The GS-Test library contains utilities designed to simplify testing of applications implemented using GigaSpaces.
 
 #### Running an embedded Processing Unit
-The `PuConfigurers` class contains factory methods for builders for different types of processing units (partitioned pu, mirror pu).
+The `PuConfigurers`/`StandalonePuConfigurers` classes contains factory methods for builders for different types of processing units (partitioned pu, mirror pu).
 Those can be used to create an embedded processing unit (`RunningPu`).
-The `RunningPu` extends the `org.junit.rules.TestRule` interface which makes it easy to run a processing unit "around" either an entire test class using `@ClassRule`, or around each test case using `@Rule`.
+The `RunningPu` is available as a `@TestRule` for JUnit4 and as an `Extension` for JUnit5.
 
-##### Example: Using @Rule and RunningPu to start/stop a pu around each test case
+##### Example: Using JUnit4 @Rule and RunningPu to start/stop a pu around each test case
 ```java
 class FruitTest {
   @Rule
@@ -23,7 +23,18 @@ class FruitTest {
 }
 ```
 
-##### Example: Starting/stopping a Pu explicitly
+##### Example: Using JUnit5 @RegisterExtension to start/stop a pu around each test case
+```java
+class FruitTest {
+  @RegisterExtension
+  public RunningPu fruitPu = PuConfigurers.partitionedPu("classpath:/fruit-pu.xml")
+                                          .configure();
+                                   
+  // Test cases against fruitPu
+}
+```
+
+##### Example: Starting/stopping a Pu explicitly, without any test framework
 ```java
 class FruitTest {
 
@@ -79,6 +90,18 @@ JUnit4 bindings for running as test rules.
 ``` 
 
 This artifact replaces `com.avanza.gs:gs-test` from pre-`2.1.0` versions of this library.
+
+### JUnit5
+
+JUnit5 extension bindings.
+
+```xml
+<dependency>
+  <groupId>com.avanza.gs</groupId>
+  <artifactId>gs-test-junit5</artifactId>
+  <version>2.1.0</version>
+</dependency>
+```
 
 ## Previous versions
 

--- a/gs-test-core/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
+++ b/gs-test-core/src/main/java/com/avanza/gs/test/PuXmlEmulation.java
@@ -40,7 +40,7 @@ public class PuXmlEmulation {
 		}
 	}
 
-	static Resource createPuXmlResource(Class<?> puConfig) {
+	public static Resource createPuXmlResource(Class<?> puConfig) {
 		try (InputStream in = PuXmlEmulation.class.getResourceAsStream("/pu.xml.template")) {
 			String content = StreamUtils.copyToString(in, UTF_8)
 					.replace("##CLASSNAME##", puConfig.getName());

--- a/gs-test-junit4/src/main/java/com/avanza/gs/test/RunningPu.java
+++ b/gs-test-junit4/src/main/java/com/avanza/gs/test/RunningPu.java
@@ -22,11 +22,11 @@ import org.junit.runners.model.Statement;
 /**
  * JUnit4 {@code TestRule} implementation of {@code StandaloneRunningPu}.
  * <p>
- * Example usage:
+ * Example usage in a JUnit 4 test class:
  * <pre>
- * {@literal @}Rule
- *  public RunningPu fruitPu = PuConfigurers.partitionedPu("pu.xml")
- *                                          .configure();
+ * &#64;Rule
+ * public RunningPu runningPu = PuConfigurers.partitionedPu("pu.xml")
+ *                                           .configure();
  * </pre>
  */
 public final class RunningPu extends StandaloneRunningPu implements TestRule {

--- a/gs-test-junit5/pom.xml
+++ b/gs-test-junit5/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.avanza.gs</groupId>
+		<artifactId>gs-test-parent</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>gs-test-junit5</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>gs-test-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-banned-dependencies</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<!-- this module should never have a dependency to junit4 -->
+										<exclude>junit:junit</exclude>
+									</excludes>
+								</bannedDependencies>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/EmbeddedSpace.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/EmbeddedSpace.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.avanza.gs.test.StandaloneEmbeddedSpace;
+
+/**
+ * JUnit5 {@code Extension} implementation of {@code StandaloneEmbeddedSpace}.
+ */
+public final class EmbeddedSpace extends StandaloneEmbeddedSpace implements ResourceExtension {
+
+	private static final Logger LOG = LoggerFactory.getLogger(EmbeddedSpace.class);
+
+	public EmbeddedSpace() {
+		super();
+	}
+
+	public EmbeddedSpace(String spaceName) {
+		super(spaceName);
+	}
+
+	@Override
+	public void before() {
+		start();
+	}
+
+	@Override
+	public void after() {
+		try {
+			destroy();
+		} catch (Exception e) {
+			LOG.warn("Error shutting down embedded space", e);
+		}
+	}
+}

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/MirrorPuConfigurer.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/MirrorPuConfigurer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import org.springframework.core.io.Resource;
+
+import com.avanza.gs.test.AbstractMirrorPuConfigurer;
+
+public final class MirrorPuConfigurer extends AbstractMirrorPuConfigurer<MirrorPuConfigurer, RunningPu> {
+	public MirrorPuConfigurer(String puXmlPath) {
+		super(puXmlPath);
+	}
+
+	public MirrorPuConfigurer(Resource puConfigResource) {
+		super(puConfigResource);
+	}
+
+	@Override
+	public RunningPu configure() {
+		return new RunningPu(createPuRunner());
+	}
+}

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/PartitionedPuConfigurer.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/PartitionedPuConfigurer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import org.springframework.core.io.Resource;
+
+import com.avanza.gs.test.AbstractPartitionedPuConfigurer;
+
+public final class PartitionedPuConfigurer extends AbstractPartitionedPuConfigurer<PartitionedPuConfigurer, RunningPu> {
+	public PartitionedPuConfigurer(String puXmlPath) {
+		super(puXmlPath);
+	}
+
+	public PartitionedPuConfigurer(Resource puConfigResource) {
+		super(puConfigResource);
+	}
+
+	@Override
+	public RunningPu configure() {
+		return new RunningPu(createPuRunner());
+	}
+}

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/PuConfigurers.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/PuConfigurers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import static com.avanza.gs.test.PuXmlEmulation.createPuXmlResource;
+
+import org.springframework.core.io.Resource;
+
+public final class PuConfigurers {
+
+	private PuConfigurers() {
+	}
+
+	public static PartitionedPuConfigurer partitionedPu(String puXmlPath) {
+		return new PartitionedPuConfigurer(puXmlPath);
+	}
+
+	public static PartitionedPuConfigurer partitionedPu(Resource puConfigResource) {
+		return new PartitionedPuConfigurer(puConfigResource);
+	}
+
+	public static PartitionedPuConfigurer partitionedPu(Class<?> puConfig) {
+		return partitionedPu(createPuXmlResource(puConfig));
+	}
+
+	public static MirrorPuConfigurer mirrorPu(String puXmlPath) {
+		return new MirrorPuConfigurer(puXmlPath);
+	}
+
+	public static MirrorPuConfigurer mirrorPu(Resource puConfigResource) {
+		return new MirrorPuConfigurer(puConfigResource);
+	}
+
+	public static MirrorPuConfigurer mirrorPu(Class<?> mirrorConfig) {
+		return mirrorPu(createPuXmlResource(mirrorConfig));
+	}
+
+}

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/ResourceExtension.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/ResourceExtension.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+/**
+ * This interface makes sure that {@link #before} and {@link #after} are called
+ * at most once, regardless of whether the implementing class is used in tests
+ * as a {@code static} instance (which would normally use the callbacks from
+ * {@link BeforeAllCallback}), or as a non-{@code static} instance (which would
+ * normally use {@link BeforeEachCallback}).
+ */
+interface ResourceExtension extends BeforeAllCallback, BeforeEachCallback {
+
+	void before() throws Exception;
+
+	void after() throws Exception;
+
+	@Override
+	default void beforeAll(ExtensionContext context) throws Exception {
+		ensureInitialized(context);
+	}
+
+	@Override
+	default void beforeEach(ExtensionContext context) throws Exception {
+		if (context.getParent().map(this::getStore).map(store -> store.get(this)).isEmpty()) {
+			ensureInitialized(context);
+		}
+	}
+
+	private Store getStore(ExtensionContext context) {
+		return context.getStore(Namespace.create(this, context.getRequiredTestClass()));
+	}
+
+	private void ensureInitialized(ExtensionContext context) throws Exception {
+		Store store = getStore(context);
+		if (store.get(this) == null) {
+			before();
+			store.put(this, (Store.CloseableResource) this::after);
+		}
+	}
+
+}

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/RunningPu.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/RunningPu.java
@@ -24,11 +24,11 @@ import com.avanza.gs.test.StandaloneRunningPu;
 /**
  * JUnit5 {@code @Extension} implementation of {@code StandaloneRunningPu}.
  * <p>
- * Example usage:
+ * Example usage in a JUnit 5 test class:
  * <pre>
- * {@literal @}RegisterExtension
- *  public RunningPu fruitPu = PuConfigurers.partitionedPu("pu.xml")
- *                                          .configure();
+ * &#64;RegisterExtension
+ * RunningPu runningPu = PuConfigurers.partitionedPu("pu.xml")
+ *                                    .configure();
  * </pre>
  */
 public final class RunningPu extends StandaloneRunningPu implements ResourceExtension {

--- a/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/RunningPu.java
+++ b/gs-test-junit5/src/main/java/com/avanza/gs/test/junit5/RunningPu.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.avanza.gs.test.PuRunner;
+import com.avanza.gs.test.StandaloneRunningPu;
+
+/**
+ * JUnit5 {@code @Extension} implementation of {@code StandaloneRunningPu}.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@literal @}RegisterExtension
+ *  public RunningPu fruitPu = PuConfigurers.partitionedPu("pu.xml")
+ *                                          .configure();
+ * </pre>
+ */
+public final class RunningPu extends StandaloneRunningPu implements ResourceExtension {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RunningPu.class);
+
+	public RunningPu(PuRunner runner) {
+		super(runner);
+	}
+
+	@Override
+	public void before() throws Exception {
+		if (isAutostart()) {
+			start();
+		}
+	}
+
+	@Override
+	public void after() {
+		try {
+			stop();
+		} catch (Exception e) {
+			LOG.warn("Error while shutting down PU", e);
+		}
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/EmbeddedSpaceAsRuleTest.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/EmbeddedSpaceAsRuleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openspaces.core.GigaSpace;
+
+import com.avanza.gs.test.junit5.helpers.FruitPojo;
+
+public class EmbeddedSpaceAsRuleTest {
+
+	@RegisterExtension
+	public final EmbeddedSpace embeddedSpace = new EmbeddedSpace("space-name");
+
+	@Test
+	public void testPersistingAndReading() {
+		GigaSpace gigaSpace = embeddedSpace.getGigaSpace();
+		gigaSpace.write(new FruitPojo("orange"));
+
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "orange");
+		assertNotNull(fruit);
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/PuWithMirrorTest.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/PuWithMirrorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openspaces.core.GigaSpace;
+
+import com.avanza.gs.test.junit5.helpers.FruitPojo;
+import com.avanza.gs.test.junit5.helpers.TestSpaceSynchronizationEndpoint;
+import com.gigaspaces.sync.DataSyncOperation;
+import com.gigaspaces.sync.DataSyncOperationType;
+
+public class PuWithMirrorTest {
+
+	@RegisterExtension
+	public final RunningPu fruitPu = PuConfigurers.partitionedPu("/fruit-pu.xml")
+			.numberOfPrimaries(1)
+			.numberOfBackups(1)
+			.configure();
+
+	@RegisterExtension
+	public final RunningPu mirrorPu = PuConfigurers.mirrorPu("/fruit-mirror-pu.xml")
+			.configure();
+
+	@Test
+	public void testDataIsPersistedToMirror() {
+		GigaSpace gigaSpace = fruitPu.getClusteredGigaSpace();
+		gigaSpace.write(new FruitPojo("apple"));
+
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "apple");
+		assertNotNull(fruit);
+
+		TestSpaceSynchronizationEndpoint spaceSynchronizationEndpoint = mirrorPu.getPrimaryInstanceApplicationContext(0)
+				.getBean(TestSpaceSynchronizationEndpoint.class);
+
+		await().until(spaceSynchronizationEndpoint::getDataSyncOperations, not(empty()));
+
+		DataSyncOperation dataSyncOperation = spaceSynchronizationEndpoint.getDataSyncOperations().get(0);
+		assertThat(dataSyncOperation.getDataSyncOperationType(), is(DataSyncOperationType.WRITE));
+		assertThat((FruitPojo) dataSyncOperation.getDataAsObject(), is(new FruitPojo("apple")));
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/RunningPuAsExtensionTest.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/RunningPuAsExtensionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openspaces.core.GigaSpace;
+
+import com.avanza.gs.test.junit5.helpers.FruitPojo;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RunningPuAsExtensionTest {
+
+	@RegisterExtension
+	public final RunningPu runningPu = PuConfigurers.partitionedPu("/fruit-pu.xml")
+			.numberOfPrimaries(1)
+			.numberOfBackups(0)
+			.configure();
+
+	@Test
+	@Order(1)
+	public void testSaveAndRead() {
+		GigaSpace gigaSpace = runningPu.getClusteredGigaSpace();
+		gigaSpace.write(new FruitPojo("apple"));
+
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "apple");
+		assertNotNull(fruit);
+	}
+
+	@Test
+	@Order(2)
+	public void verifyPersistedDataIsResetBetweenTests() {
+		GigaSpace gigaSpace = runningPu.getClusteredGigaSpace();
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "apple");
+		assertNull(fruit);
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/RunningPuAsStaticExtensionTest.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/RunningPuAsStaticExtensionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openspaces.core.GigaSpace;
+
+import com.avanza.gs.test.junit5.helpers.FruitPojo;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RunningPuAsStaticExtensionTest {
+
+	@RegisterExtension
+	public static final RunningPu runningPu = PuConfigurers.partitionedPu("/fruit-pu.xml")
+			.numberOfPrimaries(1)
+			.numberOfBackups(0)
+			.configure();
+
+	@Test
+	@Order(1)
+	public void testDataIsSavedAndRead() {
+		GigaSpace gigaSpace = runningPu.getClusteredGigaSpace();
+		gigaSpace.write(new FruitPojo("apple"));
+
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "apple");
+		assertNotNull(fruit);
+	}
+
+	@Test
+	@Order(2)
+	public void testDataIsStoredBetweenTests() {
+		GigaSpace gigaSpace = runningPu.getClusteredGigaSpace();
+
+		FruitPojo fruit = gigaSpace.readById(FruitPojo.class, "apple");
+		assertNotNull(fruit);
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/helpers/FruitPojo.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/helpers/FruitPojo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5.helpers;
+
+import java.util.Objects;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+
+@SpaceClass
+public class FruitPojo {
+
+	private String id;
+
+	public FruitPojo() {
+	}
+
+	public FruitPojo(String id) {
+		super();
+		this.id = id;
+	}
+
+	@SpaceId
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		FruitPojo fruitPojo = (FruitPojo) o;
+		return Objects.equals(getId(), fruitPojo.getId());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId());
+	}
+
+	@Override
+	public String toString() {
+		return "FruitPojo{" +
+				"id='" + id + '\'' +
+				'}';
+	}
+}

--- a/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/helpers/TestSpaceSynchronizationEndpoint.java
+++ b/gs-test-junit5/src/test/java/com/avanza/gs/test/junit5/helpers/TestSpaceSynchronizationEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.gs.test.junit5.helpers;
+
+import static java.util.Collections.unmodifiableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.gigaspaces.sync.DataSyncOperation;
+import com.gigaspaces.sync.OperationsBatchData;
+import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
+
+public class TestSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoint {
+
+	private final List<DataSyncOperation> dataSyncOperations = new ArrayList<>();
+
+	@Override
+	public void onOperationsBatchSynchronization(OperationsBatchData batchData) {
+		dataSyncOperations.addAll(List.of(batchData.getBatchDataItems()));
+	}
+
+	public List<DataSyncOperation> getDataSyncOperations() {
+		return unmodifiableList(dataSyncOperations);
+	}
+}

--- a/gs-test-junit5/src/test/resources/fruit-mirror-pu.xml
+++ b/gs-test-junit5/src/test/resources/fruit-mirror-pu.xml
@@ -1,0 +1,18 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:os-core="http://www.openspaces.org/schema/core"
+	   xsi:schemaLocation="http://www.openspaces.org/schema/core http://www.openspaces.org/schema/core/openspaces-core.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<bean id="spaceSyncEndpoint" class="com.avanza.gs.test.junit5.helpers.TestSpaceSynchronizationEndpoint"/>
+
+	<context:annotation-config/>
+	<os-core:mirror id="mirrorGigaSpace" url="/./fruit-space-mirror" space-sync-endpoint="spaceSyncEndpoint">
+		<os-core:source-space name="fruit-space" partitions="1" backups="1"/>
+	</os-core:mirror>
+
+	<os-core:giga-space id="gigaSpace" space="mirrorGigaSpace"/>
+
+</beans>

--- a/gs-test-junit5/src/test/resources/fruit-pu.xml
+++ b/gs-test-junit5/src/test/resources/fruit-pu.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:os-core="http://www.openspaces.org/schema/core"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.openspaces.org/schema/core http://www.openspaces.org/schema/core/openspaces-core.xsd">
+
+	<os-core:giga-space id="gigaSpace" space="fruitSpace"/>
+	<os-core:space id="fruitSpace" url="/./fruit-space" mirror="true">
+		<os-core:properties>
+			<props>
+				<prop key="cluster-config.mirror-service.url">jini://*/*/fruit-space-mirror</prop>
+				<prop key="space-config.engine.cache_policy">1</prop>
+				<prop key="space-config.external-data-source.usage">read-only</prop>
+				<prop key="cluster-config.cache-loader.external-data-source">true</prop>
+				<prop key="cluster-config.cache-loader.central-data-source">true</prop>
+			</props>
+		</os-core:properties>
+	</os-core:space>
+
+</beans>

--- a/gs-test-junit5/src/test/resources/log4j2.xml
+++ b/gs-test-junit5/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %-5level %logger{36} - %msg%n"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="info">
+			<AppenderRef ref="Console"/>
+		</Root>
+	</Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 		<module>gs-test-core</module>
 		<module>gs-test</module>
 		<module>gs-test-junit4</module>
+		<module>gs-test-junit5</module>
 	</modules>
 	<name>${project.artifactId}</name>
 	<description>${project.artifactId}</description>
@@ -136,6 +137,7 @@
 		<spring.version>5.3.7</spring.version>
 		<gigaspaces.version>16.1.0</gigaspaces.version>
 		<junit.version>4.13.2</junit.version>
+		<junit-jupiter.version>5.8.2</junit-jupiter.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<awaitility.version>4.1.0</awaitility.version>
 		<slf4j.version>1.7.32</slf4j.version>
@@ -233,6 +235,13 @@
 						<artifactId>hamcrest-core</artifactId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit-jupiter.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
* Provides support for running tests as an JUnit5 extension using `@RegisterExtension`
* Uses `ResourceExtension` to reproduce equal functionality to JUnit 4 `@ClassRule` and `@Rule`
---
Inspired by the JUnit5 solution in https://github.com/AvanzaBank/gs-test/pull/28

Targeted at https://github.com/AvanzaBank/gs-test/tree/tp-687-split-to-multi-module to make which changes belongs to this PR clearer and easier to review.