### PR TITLE
Exclude guava from `curator-test`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
 				<groupId>org.apache.curator</groupId>
 				<artifactId>curator-test</artifactId>
 				<version>${curator.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.google.guava</groupId>
+						<artifactId>guava</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
* guava is shaded in `curator` and only included for some methods that aren't in use for this use case
* This removes an unnecessary dependency to guava in projects having a dependency to `gs-test`
---
see https://cwiki.apache.org/confluence/display/CURATOR/TN13