### PR TITLE
TP-1258: Make MirrorPuConfigurer more like PartitionedPuConfigurer

### DIFF
--- a/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
@@ -30,6 +30,16 @@ public class MirrorPuConfigurer {
 		this.puXmlPath = puXmlPath;
 	}
 
+	public MirrorPuConfigurer contextProperties(Properties properties) {
+		this.properties = properties;
+		return this;
+	}
+
+	public MirrorPuConfigurer contextProperties(ContextProperties properties) {
+		this.properties = properties.getProperties();
+		return this;
+	}
+
 	public MirrorPuConfigurer contextProperty(String propertyName, String propertyValue) {
 		this.properties.setProperty(propertyName, propertyValue);
 		return this;

--- a/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/MirrorPuConfigurer.java
@@ -30,11 +30,21 @@ public class MirrorPuConfigurer {
 		this.puXmlPath = puXmlPath;
 	}
 
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public MirrorPuConfigurer contextProperties(Properties properties) {
 		this.properties = properties;
 		return this;
 	}
 
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public MirrorPuConfigurer contextProperties(ContextProperties properties) {
 		this.properties = properties.getProperties();
 		return this;

--- a/src/main/java/com/avanza/gs/test/PartitionedPu.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPu.java
@@ -42,7 +42,7 @@ public final class PartitionedPu implements PuRunner {
 	private final Integer numberOfPrimaries;
 	private final Integer numberOfBackups;
 	private final Properties contextProperties = new Properties();
-	private final Map<String, Properties> beanProperies = new HashMap<>();
+	private final Map<String, Properties> beanProperties = new HashMap<>();
 	private final String lookupGroupName;
 	private final boolean autostart;
 	private final ApplicationContext parentContext;
@@ -53,7 +53,7 @@ public final class PartitionedPu implements PuRunner {
 		this.numberOfBackups = configurer.numberOfBackups;
 		this.numberOfPrimaries = configurer.numberOfPrimaries;
 		this.contextProperties.putAll(configurer.contextProperties);
-		this.beanProperies.putAll(configurer.beanProperties);
+		this.beanProperties.putAll(configurer.beanProperties);
 		this.lookupGroupName = configurer.lookupGroupName;
 		this.autostart = configurer.autostart;
 		this.parentContext = configurer.parentContext;
@@ -115,7 +115,7 @@ public final class PartitionedPu implements PuRunner {
 	private BeanLevelProperties createBeanLevelProperties() {
 		BeanLevelProperties beanLevelProperties = new BeanLevelProperties();
 		beanLevelProperties.setContextProperties(contextProperties);
-		for (Map.Entry<String, Properties> beanProperties : beanProperies.entrySet()) {
+		for (Map.Entry<String, Properties> beanProperties : beanProperties.entrySet()) {
 			beanLevelProperties.setBeanProperties(beanProperties.getKey(), beanProperties.getValue());
 		}
 		return beanLevelProperties;

--- a/src/main/java/com/avanza/gs/test/PartitionedPu.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPu.java
@@ -53,7 +53,7 @@ public final class PartitionedPu implements PuRunner {
 		this.numberOfBackups = configurer.numberOfBackups;
 		this.numberOfPrimaries = configurer.numberOfPrimaries;
 		this.contextProperties.putAll(configurer.contextProperties);
-		this.beanProperies.putAll(configurer.beanProperies);
+		this.beanProperies.putAll(configurer.beanProperties);
 		this.lookupGroupName = configurer.lookupGroupName;
 		this.autostart = configurer.autostart;
 		this.parentContext = configurer.parentContext;

--- a/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
@@ -85,11 +85,21 @@ public final class PartitionedPuConfigurer {
 		return new RunningPuImpl(new PartitionedPu(this));
 	}
 
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public PartitionedPuConfigurer contextProperties(Properties properties) {
 		this.contextProperties = properties;
 		return this;
 	}
-	
+
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public PartitionedPuConfigurer contextProperties(ContextProperties properties) {
 		this.contextProperties = properties.getProperties();
 		return this;

--- a/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
+++ b/src/main/java/com/avanza/gs/test/PartitionedPuConfigurer.java
@@ -28,7 +28,7 @@ public final class PartitionedPuConfigurer {
 	int numberOfBackups = 0;
 	boolean startAsync = false;
 	Properties contextProperties = new Properties();
-	Map<String, Properties> beanProperies = new HashMap<>();
+	Map<String, Properties> beanProperties = new HashMap<>();
 	String lookupGroupName = JVMGlobalLus.getLookupGroupName();
 	String spaceName = "test-space";
 	public boolean autostart = true;
@@ -55,7 +55,7 @@ public final class PartitionedPuConfigurer {
 	}
 
 	public PartitionedPuConfigurer beanProperties(String beanName, Properties beanProperties) {
-		this.beanProperies.put(beanName, beanProperties);
+		this.beanProperties.put(beanName, beanProperties);
 		return this;
 	}
 


### PR DESCRIPTION
* This commit also fixes a misspelled variable name.