### PR TITLE
TP-1258: Make MirrorPuConfigurer more like PartitionedPuConfigurer

### DIFF
--- a/gs-test-core/src/main/java/com/avanza/gs/test/AbstractMirrorPuConfigurer.java
+++ b/gs-test-core/src/main/java/com/avanza/gs/test/AbstractMirrorPuConfigurer.java
@@ -24,7 +24,7 @@ public abstract class AbstractMirrorPuConfigurer<T extends AbstractMirrorPuConfi
 
 	private final String puXmlPath;
 	private final Resource puConfigResource;
-	private final Properties properties = new Properties();
+	private Properties properties = new Properties();
 	private ApplicationContext parentContext;
 	private String lookupLocator;
 
@@ -36,6 +36,26 @@ public abstract class AbstractMirrorPuConfigurer<T extends AbstractMirrorPuConfi
 	public AbstractMirrorPuConfigurer(Resource puConfigResource) {
 		this.puXmlPath = null;
 		this.puConfigResource = puConfigResource;
+	}
+
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
+	public T contextProperties(Properties properties) {
+		this.properties = properties;
+		return me();
+	}
+
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
+	public T contextProperties(ContextProperties properties) {
+		this.properties = properties.getProperties();
+		return me();
 	}
 
 	public T contextProperty(String propertyName, String propertyValue) {

--- a/gs-test-core/src/main/java/com/avanza/gs/test/AbstractPartitionedPuConfigurer.java
+++ b/gs-test-core/src/main/java/com/avanza/gs/test/AbstractPartitionedPuConfigurer.java
@@ -95,11 +95,21 @@ public abstract class AbstractPartitionedPuConfigurer<T extends AbstractPartitio
 		return new PartitionedPu(this);
 	}
 
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public T contextProperties(Properties properties) {
 		this.contextProperties = properties;
 		return me();
 	}
-	
+
+	/**
+	 * @deprecated Use {@link #contextProperty(String, String)} instead.
+	 * E.g. {@code .contextProperty("configSourceId", serviceRegistry.getConfigSourceId())) }
+	 */
+	@Deprecated
 	public T contextProperties(ContextProperties properties) {
 		this.contextProperties = properties.getProperties();
 		return me();


### PR DESCRIPTION
* And deprecate contextProperties methods.