### PR TITLE
TP-1276: Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,8 +184,16 @@
 				<version>${gigaspaces.version}</version>
 				<exclusions>
 					<exclusion>
+						<groupId>com.github.oshi</groupId>
+						<artifactId>oshi-core</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>org.junit.jupiter</groupId>
 						<artifactId>*</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.xerial</groupId>
+						<artifactId>sqlite-jdbc</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
This removes transitive dependencies on: 
* `org.xerial:sqlite-jdbc` (this is one huge artifact)
* `com.github.oshi:oshi-core` (unused and unnecessary)